### PR TITLE
Allow all react versions greater than 15.0.0 for peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prettier": "prettier --write --bracket-spacing=false --single-quote --trailing-comma src/*.js src/**/*.js"
   },
   "peerDependencies": {
-    "react": "^15.0.0"
+    "react": ">=15.0.0"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Hi there,
Just wanted to say I'm really grateful for this library!

This PR proposes accepting all versions of react greater than 15 rather than only in the 15 major version range

That is pretty lenient but given the stability of react I think it is probably ok, and avoids warnings during install about missing peer deps from yarn and npm